### PR TITLE
ci: 🎡 build の npmスクリプト を実行するステップを追加した

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,6 @@ jobs:
       - name: $ yarn install する
         run: |
           yarn install --immutable
+      - name: $ yarn build する
+        run: |
+          yarn build


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/ci.yml` file. The change adds a new step to the CI workflow to build the project using `yarn`.

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR44-R46): Added a new step to run `yarn build` after `yarn install`.